### PR TITLE
fix(services): remove manual setting of Content-Type header when FormData is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@upfrontjs/framework",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@upfrontjs/framework",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@upfrontjs/framework",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "Data handling framework complementary to backend model systems.",
     "main": "index.min.js",
     "module": "index.es.min.js",

--- a/src/Services/API.ts
+++ b/src/Services/API.ts
@@ -127,9 +127,7 @@ export default class API implements ApiCaller {
             // if not a GET method
             if (initOptions.method !== 'GET' && initOptions.method !== 'HEAD') {
                 if (data instanceof FormData) {
-                    if (!headers.has('Content-Type')) {
-                        headers.set('Content-Type', 'multipart/form-data');
-                    }
+                    // fetch will set the Content-Type https://fetch.spec.whatwg.org/#ref-for-formdata%E2%91%A1
                     initOptions.body = data;
                 } else {
                     if (!headers.has('Content-Type')) {

--- a/tests/Services/API.test.ts
+++ b/tests/Services/API.test.ts
@@ -121,18 +121,6 @@ describe('API', () => {
             expect(config.body).toBeUndefined();
         });
 
-        it('should prepare FormData', async () => {
-            const form = new FormData();
-            form.append('key', 'value');
-
-            const config = (await api.getConfig(url, 'post', form)).requestInit;
-
-            expect(config.body).toBeInstanceOf(FormData);
-            expect((config.body as FormData).get('key')).toBe('value');
-            // @ts-expect-error
-            expect(config.headers.get('Content-Type')).toBe('multipart/form-data');
-        });
-
         it('should stringify the given data', async () => {
             const data = { custom: 'value' };
             const config = (await api.getConfig(url, 'post', data)).requestInit;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://upfrontjs.com/prologue/contributing.html
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

