### PR TITLE
fix(attributes): updated `toJSON` to use `getRawAttributes`

### DIFF
--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -20,6 +20,8 @@ jobs:
         run: npm run docs:api
       - name: Update gh-pages branch
         run: |
+          git config --global user.email "nandor.kraszlan@gmail.com"
+          git config --global user.name "Nandor Kraszlan"
           cp -r ./api-docs/* ./
           git add -f assets
           git add -f classes

--- a/src/Calliope/Concerns/HasAttributes.ts
+++ b/src/Calliope/Concerns/HasAttributes.ts
@@ -686,7 +686,7 @@ export default class HasAttributes extends GuardsAttributes implements Jsonable,
      * @inheritDoc
      */
     public toJSON<T extends ReturnType<typeof JSON.parse> = RawAttributes<this>>(): T {
-        const json = this.getAttributes() as SimpleAttributes;
+        const json = this.getRawAttributes() as SimpleAttributes;
 
         const relations = (this as unknown as HasRelations).getRelations();
 
@@ -696,7 +696,7 @@ export default class HasAttributes extends GuardsAttributes implements Jsonable,
                 return;
             }
 
-            json[relation] = (relations[relation]! as ModelCollection<Model>).map(model => model.toJSON()).toArray();
+            json[relation] = (relations[relation] as ModelCollection<Model>).map(model =>  model.toJSON()).toArray();
         });
 
         return json as unknown as T;

--- a/tests/Calliope/Concerns/HasAttributes.test.ts
+++ b/tests/Calliope/Concerns/HasAttributes.test.ts
@@ -4,6 +4,7 @@ import ModelCollection from '../../../src/Calliope/ModelCollection';
 import { isEqual } from 'lodash';
 import Contract from '../../mock/Models/Contract';
 import Team from '../../mock/Models/Team';
+import type { RawAttributes } from '../../../src';
 import { Collection } from '../../../src';
 
 let hasAttributes: User;
@@ -747,6 +748,20 @@ describe('HasAttributes', () => {
                     { shiftAttr: 1 }
                 ]
             });
+        });
+
+        it('should take attributes in their raw form', () => {
+            // raw because json isn't something that is displayed to the user
+            const shift = Shift.create({ attr: 1 });
+
+            shift.getAttrAttribute = (value: number) => {
+                return value + 1;
+            };
+
+            hasAttributes.addRelation('shifts', shift);
+            expect((hasAttributes.toJSON().shifts as [RawAttributes<Shift>])[0].attr).toBe(1);
+
+            delete shift.getAttrAttribute;
         });
     });
 

--- a/tests/mock/Models/Shift.ts
+++ b/tests/mock/Models/Shift.ts
@@ -9,4 +9,8 @@ export default class Shift extends Model {
     public factory(): ShiftFactory {
         return new ShiftFactory;
     }
+
+    public get fillable(): string[] {
+        return ['*'];
+    }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://upfrontjs.com/prologue/contributing.html
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `toJSON` is meant to be used when the data is in transit or being stored. Getters, mutators and casting is meant for when the data is being displayed.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

