### PR TITLE
feat: add query params to find & findMany methods

### DIFF
--- a/src/Calliope/Concerns/BuildsQuery.ts
+++ b/src/Calliope/Concerns/BuildsQuery.ts
@@ -27,7 +27,7 @@ export type QueryParams = Partial<{
     offset: number;
     limit: number;
     page: number;
-}>;
+}> & Record<string, unknown>;
 
 export default class BuildsQuery extends HasAttributes {
     /**

--- a/src/Calliope/Concerns/CallsApi.ts
+++ b/src/Calliope/Concerns/CallsApi.ts
@@ -174,7 +174,7 @@ export default class CallsApi extends BuildsQuery {
      */
     // @ts-expect-error - despite TS2526, it still infers correctly
     public async get<T extends Model = this>(
-        queryParameters?: QueryParams & Record<string, unknown>
+        queryParameters?: QueryParams
     ): Promise<ModelCollection<T> | T> {
         return this.call('GET', queryParameters)
             .then(responseData => this.newInstanceFromResponseData(
@@ -191,7 +191,7 @@ export default class CallsApi extends BuildsQuery {
      */
     public static async get<T extends StaticToThis>(
         this: T,
-        queryParameters?: QueryParams & Record<string, unknown>
+        queryParameters?: QueryParams
     ): Promise<ModelCollection<T['prototype']> | T['prototype']> {
         return new this().get(queryParameters);
     }

--- a/src/Calliope/Model.ts
+++ b/src/Calliope/Model.ts
@@ -8,6 +8,7 @@ import { finish } from '../Support/string';
 import type { MaybeArray, StaticToThis } from '../Support/type';
 import { cloneDeep } from 'lodash';
 import { isObjectLiteral } from '../Support/function';
+import type { QueryParams } from './Concerns/BuildsQuery';
 
 export default class Model extends SoftDeletes implements HasFactory {
     /**
@@ -294,11 +295,15 @@ export default class Model extends SoftDeletes implements HasFactory {
      * Find the model based on the given id.
      *
      * @param {string|number} id
+     * @param {object=} queryParameters
      */
-    public async find<T extends this>(id: number | string): Promise<T> {
+    public async find<T extends this>(
+        id: number | string,
+        queryParameters?: QueryParams
+    ): Promise<T> {
         return await this
             .setEndpoint(finish(this.getEndpoint(), '/') + String(id))
-            .get() as T;
+            .get(queryParameters) as T;
     }
 
     /**
@@ -306,17 +311,25 @@ export default class Model extends SoftDeletes implements HasFactory {
      *
      * @see Model.prototype.find
      */
-    public static async find<T extends StaticToThis>(this: T, id: number | string): Promise<T['prototype']> {
-        return new this().find(id);
+    public static async find<T extends StaticToThis>(
+        this: T,
+        id: number | string,
+        queryParameters?: QueryParams
+    ): Promise<T['prototype']> {
+        return new this().find(id, queryParameters);
     }
 
     /**
      * Return multiple models based on the given ids.
      *
      * @param {string[]|number[]} ids
+     * @param {object=} queryParameters
      */
-    public async findMany<T extends this>(ids: (number | string)[]): Promise<ModelCollection<T>> {
-        let response = await this.whereKey(ids).get<T>();
+    public async findMany<T extends this>(
+        ids: (number | string)[],
+        queryParameters?: QueryParams
+    ): Promise<ModelCollection<T>> {
+        let response = await this.whereKey(ids).get<T>(queryParameters);
 
         if (response instanceof Model) {
             response = new ModelCollection([response]);
@@ -332,9 +345,10 @@ export default class Model extends SoftDeletes implements HasFactory {
      */
     public static async findMany<T extends StaticToThis>(
         this: T,
-        ids: (number | string)[]
+        ids: (number | string)[],
+        queryParameters?: QueryParams
     ): Promise<ModelCollection<T['prototype']>> {
-        return new this().findMany(ids);
+        return new this().findMany(ids, queryParameters);
     }
 
     /**

--- a/src/Contracts/FormatsQueryParameters.ts
+++ b/src/Contracts/FormatsQueryParameters.ts
@@ -9,5 +9,5 @@ export default interface FormatsQueryParameters {
      *
      * @param {QueryParams} parameters
      */
-    formatQueryParameters: (parameters: QueryParams & Record<string, any>) => Record<string, any>;
+    formatQueryParameters: (parameters: QueryParams) => Record<string, any>;
 }

--- a/tests/Calliope/Model.test.ts
+++ b/tests/Calliope/Model.test.ts
@@ -63,7 +63,7 @@ describe('Model', () => {
     });
 
     describe('getKeyName()', () => {
-        it('should return the primary key\'s name',  () => {
+        it('should return the primary key\'s name', () => {
             expect(user.getKeyName()).toBe('id');
         });
     });
@@ -81,7 +81,7 @@ describe('Model', () => {
     });
 
     describe('getKey()', () => {
-        it('should return the primary key for the model',  () => {
+        it('should return the primary key for the model', () => {
             expect(user.getKey()).toBe(1);
             expect(user.setAttribute('id', 'value').getKey()).toBe('value');
         });
@@ -105,7 +105,7 @@ describe('Model', () => {
     });
 
     describe('is()', () => {
-        it('should determine whether two models are the same',  () => {
+        it('should determine whether two models are the same', () => {
             expect(user.is(1)).toBe(false);
             expect(user.is({})).toBe(false);
             expect(user.is({ id: user.getKey() })).toBe(false);
@@ -116,7 +116,7 @@ describe('Model', () => {
     });
 
     describe('isNot()', () => {
-        it('should determine whether two models are not the same',  () => {
+        it('should determine whether two models are not the same', () => {
             expect(user.isNot(1)).toBe(true);
             expect(user.isNot({})).toBe(true);
             expect(user.isNot({ id: user.getKey() })).toBe(true);
@@ -238,6 +238,18 @@ describe('Model', () => {
 
             expect(responseModel).toBeInstanceOf(User);
         });
+
+        it('should send a GET request with custom query params', async () => {
+            mockUserModelResponse(user);
+            await user.find(String(user.getKey()), { foo: 'bar' });
+
+            expect(getLastRequest()?.url).toBe(
+                config.get('baseEndPoint')! + '/' +
+                user.getEndpoint() + '/' +
+                String(user.getKey()) + '?' +
+                'foo=bar'
+            );
+        });
     });
 
     describe('findMany()', () => {
@@ -279,6 +291,24 @@ describe('Model', () => {
 
             expect(users).toBeInstanceOf(ModelCollection);
             expect(users).toHaveLength(1);
+        });
+
+        it('should send a GET request with custom query params', async () => {
+            fetchMock.mockResponseOnce(
+                async () => Promise.resolve(buildResponse(User.factory().times(2).createMany()))
+            );
+
+            await user.findMany([2, 3], { foo: 'bar' });
+
+            expect(getLastRequest()?.url).toBe(
+                config.get('baseEndPoint')! + '/' +
+                user.getEndpoint() + '?' +
+                'wheres[0][column]=id' +
+                '&wheres[0][operator]=in' +
+                '&wheres[0][value][0]=2&wheres[0][value][1]=3' +
+                '&wheres[0][boolean]=and' +
+                '&foo=bar'
+            );
         });
     });
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://upfrontjs.com/prologue/contributing.html
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds the ability to add query parameters to find requests, the same way you can call the get method
**Example**:
```ts
new User().find(1, { append: ['profile'] });
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

